### PR TITLE
F4llstars update tags

### DIFF
--- a/TrackingProgress.md
+++ b/TrackingProgress.md
@@ -155,7 +155,7 @@
 </tr>
 <tr>
   <td align=center><p>  &#9203;</p></td>
-  <td><a href="./Lucky Number">Lucky numbers</td>
+  <td><a href="./Lucky Number">Lucky numbers</a></td>
   <td>Python, C++</td>
 </tr>
 <tr>

--- a/TrackingProgress.md
+++ b/TrackingProgress.md
@@ -354,7 +354,7 @@
 </tr>
 <tr>
   <td align=center><p>  &#9203;</p></td>
-  <td><a href='./Kaprekars Numbers'>Kaprekars numbers</td>
+  <td><a href='./Kaprekars Numbers'>Kaprekars numbers</a></td>
   <td>Python</td>
 </tr>
 <tr>


### PR DESCRIPTION
### Updated TrackingProgress.md

I updated two sections.

1. Kaprekars
2. Lucky Number

Each section was missing their closing a-tag \</a\>. The a-tags were added prior to the \</td\> tags. These changes where based off the layouts of the other sections.

### Kaprekars Section
```markdown
<tr>
  <td align=center><p>  &#9203;</p></td>
- <td><a href='./Kaprekars Numbers'>Kaprekars numbers</td>
+ <td><a href='./Kaprekars Numbers'>Kaprekars numbers</a></td>
  <td>Python</td>
</tr>
```

### Lucky Number Section
```markdown
<tr>
  <td align=center><p>  &#9203;</p></td>
- <td><a href="./Lucky Number">Lucky numbers</td>
+ <td><a href="./Lucky Number">Lucky numbers</a></td>
  <td>Python, C++</td>
</tr>
```
<br>
itsf4llofstars
